### PR TITLE
Adjust project name and USD amount

### DIFF
--- a/perspectives/sharon-studies.rst
+++ b/perspectives/sharon-studies.rst
@@ -24,7 +24,7 @@ I don’t have a software background. I studied Economics and Statistics and enj
 
 I wanted to become a “computer expert” and decided I needed to study Computer Science instead. But I would forfeit the Kenyan government sponsorship I already had, and it would be unaffordably expensive (I didn’t even dare mention it to my parents). There was another option: a degree at a U.S. university - if I could obtain financial assistance to cover all the costs.
 
-I interrupted my studies to earn some money, and focused on applying for opportunities offered by U.S. colleges. I did writing jobs; I managed to buy a laptop; I studied for and took U.S. examinations, and made multiple applications to universities. And eventually, I received an offer, including financial aid - but it would only cover 75% of the costs. I would need to find another USD 2200 each year, which was out of the question for me.
+I interrupted my studies to earn some money, and focused on applying for opportunities offered by U.S. colleges. I did writing jobs; I managed to buy a laptop; I studied for and took U.S. examinations, and made multiple applications to universities. And eventually, I received an offer, including financial aid - but it would only cover 75% of the costs. I would need to find another USD 22000 each year, which was out of the question for me.
 
 
 Doing it myself
@@ -36,7 +36,7 @@ I signed up for online courses, read books and articles, watched YouTube videos,
 
 I found that some things worked well and some didn’t. I discovered that I was too impatient for videos and learned better from books. I did not feel welcome at some meetups. I observed a clique mentality, and saw an unwillingness to help others. I even saw some individuals lording over others and using their positions of leadership and expertise to demean people, or gain favours in exchange for help, and I realised that communities without effective policies could be undermined by the behaviour of individuals.
 
-I continued in my writing jobs and with the programming skills I had developed, I was accepted for a software internship, with the Linux Foundation, working on Tremor. That led to a contract developer role with a German company, and another internship via `Outreachy <https://www.outreachy.org>`_ to work on Neutron.
+I continued in my writing jobs and with the programming skills I had developed, I was accepted for a software internship, with the Linux Foundation, working on Tremor. That led to a contract developer role with a German company, and another internship via `Outreachy <https://www.outreachy.org>`_ to work on OpenStack Neutron.
 
 After that internship, I went back to my studies, and nine years after I started it, I completed my degree.
 


### PR DESCRIPTION
Changed from Neutron > OpenStack Neutron to make it clearer (it is also usually referred to that way). It will also tie in nicely to the rubric section - contributing to OpenStack before helped me get the role in the OpenStack team at Canonical.
Also added a zero to the tuition fee.